### PR TITLE
Debounce filter events

### DIFF
--- a/SCInspector/InputUtils.cs
+++ b/SCInspector/InputUtils.cs
@@ -1,0 +1,23 @@
+﻿namespace SCInspector
+{
+    public static class InputUtils
+    {
+        public static Action Debounce(int ms, Action func)
+        {
+            var counter = 0;
+            return () =>
+            {
+                var current = Interlocked.Increment(ref counter);
+                Task.Delay(ms).ContinueWith(task =>
+                {
+                    if (current == counter)
+                    {
+                        func();
+                    }
+
+                    task.Dispose();
+                });
+            };
+        }
+    }
+}

--- a/SCInspector/MainForm.cs
+++ b/SCInspector/MainForm.cs
@@ -1,16 +1,19 @@
 namespace SCInspector
 {
     using GameObjectEntry = KeyValuePair<IntPtr, GameObject>;
+    using static InputUtils;
 
     public partial class MainForm : Form
     {
         public MainForm()
         {
             InitializeComponent();
+            debouncedFilterListView = Debounce(500, () => Invoke(FilterListView));
         }
 
         public GameData gameData;
         private List<ListViewItem> listViewCache = new List<ListViewItem>();
+        private Action debouncedFilterListView;
 
         private void MainForm_Load(object sender, EventArgs e)
         {
@@ -247,17 +250,17 @@ namespace SCInspector
 
         private void searchBox_TextChanged(object sender, EventArgs e)
         {
-            FilterListView();
+            debouncedFilterListView();
         }
 
         private void classSearchBox_TextChanged(object sender, EventArgs e)
         {
-            FilterListView();
+            debouncedFilterListView();
         }
 
         private void addressSearchBox_TextChanged(object sender, EventArgs e)
         {
-            FilterListView();
+            debouncedFilterListView();
         }
 
         private void viewNamesButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
If merged, this PR will add a 500ms delay to the TextChanged events of the search boxes in the main window.

I placed the debounce function in a static `InputUtils` class to make it reusable. Feel free to suggest a name change. I'm bad at naming things.