### PR TITLE
Some small changes to Memory.cs

### DIFF
--- a/SCInspector/Memory.cs
+++ b/SCInspector/Memory.cs
@@ -18,7 +18,7 @@ namespace SCInspector
         public static extern bool WriteProcessMemory(IntPtr hProcess, IntPtr lpBaseAddress, byte[] lpBuffer, Int32 nSize, out IntPtr lpNumberOfBytesWritten);
 
         [DllImport("user32.dll", SetLastError = true)]
-        static extern IntPtr FindWindowA(string lpClassName, string lpWindowName);
+        static extern IntPtr FindWindowA(string? lpClassName, string? lpWindowName);
 
         [DllImport("user32.dll", SetLastError = true)]
         static extern uint GetWindowThreadProcessId(IntPtr hWnd, out int lpdwProcessId);
@@ -241,11 +241,11 @@ namespace SCInspector
             return temp;
         }
 
-        public static T ReadStructure<T>(IntPtr offset)
+        public static T? ReadStructure<T>(IntPtr offset)
         {
             byte[] buffer = ReadBytes(offset, (uint)Marshal.SizeOf(typeof(T)));
             GCHandle handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
-            T structure = Marshal.PtrToStructure<T>(handle.AddrOfPinnedObject());
+            T? structure = Marshal.PtrToStructure<T>(handle.AddrOfPinnedObject());
             handle.Free();
             return structure;
         }

--- a/SCInspector/Memory.cs
+++ b/SCInspector/Memory.cs
@@ -1,10 +1,9 @@
+using SCInspector.Unreal;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
-using SCInspector.Unreal;
 
 namespace SCInspector
 {
@@ -145,7 +144,7 @@ namespace SCInspector
         {
             IntPtr hwnd = FindWindowA(null, windowName);
             if (hwnd == IntPtr.Zero) return hwnd;
-            
+
             GetWindowThreadProcessId(hwnd, out pid);
             Process process = Process.GetProcessById(pid);
             if (process == null) return IntPtr.Zero;
@@ -184,7 +183,7 @@ namespace SCInspector
             WriteProcessMemory(ProcessHandle, offset, value, value.Length, out outputPtr);
         }
 
-        public static UInt32 ReadUInt8(IntPtr offset)
+        public static uint ReadUInt8(IntPtr offset)
         {
             return ReadBytes(offset, 1)[0];
         }
@@ -194,7 +193,7 @@ namespace SCInspector
             WriteBytes(offset, new byte[] { value });
         }
 
-        public static UInt16 ReadUInt16(IntPtr offset)
+        public static ushort ReadUInt16(IntPtr offset)
         {
             return BitConverter.ToUInt16(ReadBytes(offset, 2), 0);
         }
@@ -204,7 +203,7 @@ namespace SCInspector
             WriteBytes(offset, BitConverter.GetBytes(value));
         }
 
-        public static UInt32 ReadUInt32(IntPtr offset)
+        public static uint ReadUInt32(IntPtr offset)
         {
             return BitConverter.ToUInt32(ReadBytes(offset, 4), 0);
         }

--- a/SCInspector/Memory.cs
+++ b/SCInspector/Memory.cs
@@ -7,6 +7,7 @@ using System.Text;
 
 namespace SCInspector
 {
+    #pragma warning disable IDE0049
     public static class Memory
     {
         #region PInvoke
@@ -183,7 +184,7 @@ namespace SCInspector
             WriteProcessMemory(ProcessHandle, offset, value, value.Length, out outputPtr);
         }
 
-        public static uint ReadUInt8(IntPtr offset)
+        public static byte ReadUInt8(IntPtr offset)
         {
             return ReadBytes(offset, 1)[0];
         }
@@ -193,22 +194,22 @@ namespace SCInspector
             WriteBytes(offset, new byte[] { value });
         }
 
-        public static ushort ReadUInt16(IntPtr offset)
+        public static UInt16 ReadUInt16(IntPtr offset)
         {
             return BitConverter.ToUInt16(ReadBytes(offset, 2), 0);
         }
 
-        public static void WriteUInt16(IntPtr offset, ushort value)
+        public static void WriteUInt16(IntPtr offset, UInt16 value)
         {
             WriteBytes(offset, BitConverter.GetBytes(value));
         }
 
-        public static uint ReadUInt32(IntPtr offset)
+        public static UInt32 ReadUInt32(IntPtr offset)
         {
             return BitConverter.ToUInt32(ReadBytes(offset, 4), 0);
         }
 
-        public static void WriteUInt32(IntPtr offset, uint value)
+        public static void WriteUInt32(IntPtr offset, UInt32 value)
         {
             WriteBytes(offset, BitConverter.GetBytes(value));
         }

--- a/SCInspector/Memory.cs
+++ b/SCInspector/Memory.cs
@@ -89,7 +89,6 @@ namespace SCInspector
         static extern bool Module32Next(IntPtr hSnapshot, ref MODULEENTRY32 lpme);
 
         [DllImport("kernel32.dll", SetLastError = true)]
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         [SuppressUnmanagedCodeSecurity]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool CloseHandle(IntPtr hObject);

--- a/SCInspector/Memory.cs
+++ b/SCInspector/Memory.cs
@@ -257,8 +257,7 @@ namespace SCInspector
         public static Dictionary<int, IntPtr> ReadTArray(TArray array)
         {
             Dictionary<int, IntPtr> dict = new Dictionary<int, IntPtr>();
-            byte[] buffer = new byte[array.count * 4];
-            ReadProcessMemory(ProcessHandle, array.contents, buffer, buffer.Length, out outputPtr);
+            byte[] buffer = ReadBytes(array.contents, array.count * 4);
             IntPtr curPtr;
 
             for (int i = 0; i < array.count; i++)


### PR DESCRIPTION
This PR cleans up some things in Memory.cs

* Remove some deprecated/unused attributes that caused warnings
* Simplify `Read*` and `Write*` methods
* Simplify return types (`UInt32` -> `uint`) as suggested by Visual Studio
* Fix warnings in `ReadStructure`
* Pull the `ReadString` buffer size into a constant

I added two new methods, `ReadBytes` and `WriteBytes` as wrappers for `ReadProcessMemory` and `WriteProcessMemory` respectively. They make the other methods simpler. For example, `ReadUInt32` goes from this
```cs
byte[] buffer = new byte[4];
ReadProcessMemory(ProcessHandle, offset, buffer, buffer.Length, out outputPtr);
return BitConverter.ToUInt32(buffer, 0);
```
to this
```cs
return BitConverter.ToUInt32(ReadBytes(offset, 4), 0);
```